### PR TITLE
Prevent users from being able to add existing email

### DIFF
--- a/src/components/WarningSnackbar/index.tsx
+++ b/src/components/WarningSnackbar/index.tsx
@@ -1,0 +1,34 @@
+import { Alert, Snackbar } from "@mui/material";
+
+type WarningSnackbarProps = {
+  message: string;
+  openSameEmailAlert: boolean;
+  handleClose: (event?: React.SyntheticEvent | Event, reason?: string) => void;
+};
+
+export default function WarningSnackbar({
+  message,
+  openSameEmailAlert,
+  handleClose,
+}: WarningSnackbarProps) {
+  return (
+    <>
+      <Snackbar
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        open={openSameEmailAlert}
+        autoHideDuration={6000}
+        onClose={handleClose}
+      >
+        <Alert
+          data-testid="email-exist-warning"
+          onClose={handleClose}
+          severity="warning"
+          variant="filled"
+          sx={{ width: "100%" }}
+        >
+          {message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}


### PR DESCRIPTION
**Bug**
- Users were able to submit with an email that already exists in the list

**Solution**
- Implemented functionality to prevent users from submitting an email that already exists in the list. Upon submiting an existing email, an alert snackbar is displayed to promptly notify the user of the duplication. This proactive measure enhances user experience by preventing redundant submissions and promptly informing users of the encountered issue.

**Minor stuff**
-preadded few test-ids for e2e testing